### PR TITLE
add NON-ASCII column

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 on:
   workflow_dispatch:
-  # push:
-  #   tags:
-  #     - "*"
+  push:
+    tags:
+      - "*"
 
 permissions:
   contents: write
@@ -19,15 +19,15 @@ jobs:
           fetch-depth: 0
 
       - name: Set Up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.x"
         id: go
 
       - name: run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          version: ~> 1.23
-          args: release --clean -p 2
+        uses: goreleaser/goreleaser-action@v6
         env:
+          HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,11 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
 
 builds:
-  - id: id1
+  - id: chars
     binary: chars
     dir: ./cmd/chars
     ldflags:
@@ -33,7 +35,7 @@ builds:
       - goos: darwin
         goarch: ppc64le
 
-  - id: id2
+  - id: chars-win
     binary: chars
     dir: ./cmd/chars
     ldflags:
@@ -75,6 +77,7 @@ brews:
     repository:
       owner: jftuga
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TOKEN }}"
     commit_author:
       name: jftuga
       email: jftuga@users.noreply.github.com

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Determine the end-of-line format, tabs, bom, and nul characters
 * For help, run `chars -h`
 
 ```
-chars v2.4.0
+chars v2.5.0
 Determine the end-of-line format, tabs, bom, and nul
 https://github.com/jftuga/chars
 
@@ -18,10 +18,9 @@ chars [filename or file-glob 1] [filename or file-glob 2] ...
   -e string
         exclude based on regular expression; use .* instead of *
   -f string
-        fail with OS exit code=100 if any of the included characters exist; ex: -f crlf,nul,bom8
+        fail with OS exit code=100 if any of the included characters exist; ex: -f crlf,nul,bom8,nonascii
   -j	output results in JSON format; can't be used with -l; does not honor -t or -c
   -l int
-        shorten files names to a maximum of this length
         shorten files names to a maximum of this length
   -t	append a row which includes a total for each column
   -v	display version and then exit
@@ -46,17 +45,17 @@ ___
 
 ```ps1con
 PS C:\chars> .\chars.exe *
-+-----------------+------+-----+-----+------+------+-------+-----------+
-|    FILENAME     | CRLF | LF  | TAB | NUL  | BOM8 | BOM16 | BYTESREAD |
-+-----------------+------+-----+-----+------+------+-------+-----------+
-| .goreleaser.yml |    0 |  59 |   0 |    0 |    0 |     0 |      1066 |
-| LICENSE         |    0 |  21 |   0 |    0 |    0 |     0 |      1068 |
-| README.md       |    0 |  92 |   0 |    0 |    0 |     0 |      3510 |
-| chars.go        |    0 | 246 | 328 |    0 |    0 |     0 |      6477 |
-| go.mod          |    0 |  10 |   2 |    0 |    0 |     0 |       188 |
-| go.sum          |    0 |   6 |   0 |    0 |    0 |     0 |       533 |
-| testfile1       |    0 |  22 |   0 | 3223 |    0 |     1 |      6448 |
-+-----------------+------+-----+-----+------+------+-------+-----------+
++-----------------+------+-----+-----+------+------+-------+-----------+-----------+
+|    FILENAME     | CRLF | LF  | TAB | NUL  | BOM8 | BOM16 | NON-ASCII | BYTESREAD |
++-----------------+------+-----+-----+------+------+-------+-----------+-----------+
+| .goreleaser.yml |    0 |  59 |   0 |    0 |    0 |     0 |         0 |      1066 |
+| LICENSE         |    0 |  21 |   0 |    0 |    0 |     0 |         0 |      1068 |
+| README.md       |    0 |  92 |   0 |    0 |    0 |     0 |         0 |      3510 |
+| chars.go        |    0 | 246 | 328 |    0 |    0 |     0 |         0 |      6477 |
+| go.mod          |    0 |  10 |   2 |    0 |    0 |     0 |         0 |       188 |
+| go.sum          |    0 |   6 |   0 |    0 |    0 |     0 |         0 |       533 |
+| testfile1       |    0 |  22 |   0 | 3223 |    0 |     1 |        27 |      6448 |
++-----------------+------+-----+-----+------+------+-------+-----------+-----------+
 ```
 
 ## Example 2
@@ -68,15 +67,15 @@ PS C:\chars> .\chars.exe *
 
 ```ps1con
 PS C:\chars> .\chars.exe -e perf.*dat -l 32 C:\Windows\System32\p*
-+----------------------------------+------+----+-----+------+------+-------+-----------+
-|             FILENAME             | CRLF | LF | TAB | NUL  | BOM8 | BOM16 | BYTESREAD |
-+----------------------------------+------+----+-----+------+------+-------+-----------+
-| C:\Windows\System32\pcl.sep      |   11 |  0 |   0 |    0 |    0 |     0 |       150 |
-| C:\Windows\System32\perfmon.msc  | 1933 |  0 |   0 |    0 |    0 |     0 |    145519 |
-| C:\Windows\Sys...tmanagement.msc | 1945 |  0 |   0 |    0 |    0 |     0 |    146389 |
-| C:\Windows\System32\pscript.sep  |    2 |  0 |   0 |    0 |    0 |     0 |        51 |
-| C:\Windows\Sys...eryprovider.mof |    0 | 61 |   0 | 2073 |    0 |     1 |      4148 |
-+----------------------------------+------+----+-----+------+------+-------+-----------+
++----------------------------------+------+----+-----+------+------+-------+-----------+-----------+
+|             FILENAME             | CRLF | LF | TAB | NUL  | BOM8 | BOM16 | NON-ASCII | BYTESREAD |
++----------------------------------+------+----+-----+------+------+-------+-----------+-----------+
+| C:\Windows\System32\pcl.sep      |   11 |  0 |   0 |    0 |    0 |     0 |         0 |       150 |
+| C:\Windows\System32\perfmon.msc  | 1933 |  0 |   0 |    0 |    0 |     0 |         0 |    145519 |
+| C:\Windows\Sys...tmanagement.msc | 1945 |  0 |   0 |    0 |    0 |     0 |         0 |    146389 |
+| C:\Windows\System32\pscript.sep  |    2 |  0 |   0 |    0 |    0 |     0 |         0 |        51 |
+| C:\Windows\Sys...eryprovider.mof |    0 | 61 |   0 | 2073 |    0 |     1 |       987 |      4148 |
++----------------------------------+------+----+-----+------+------+-------+-----------+-----------+
 ```
 
 ## Example 3
@@ -98,6 +97,7 @@ $ curl -s https://example.com/ | chars -j
         "bom8": 0,
         "bom16": 0,
         "nul": 0,
+        "nonAscii": 0,
         "bytesRead": 1256
     }
 ]
@@ -111,11 +111,11 @@ $ curl -s https://example.com/ | chars -j
 
 ```console
 $ chars -f lf,tab /etc/group ; echo $?
-+------------+------+----+-----+-----+------+-------+-----------+
-|  FILENAME  | CRLF | LF | TAB | NUL | BOM8 | BOM16 | BYTESREAD |
-+------------+------+----+-----+-----+------+-------+-----------+
-| /etc/group |    0 | 58 |   0 |   0 |    0 |     0 |       795 |
-+------------+------+----+-----+-----+------+-------+-----------+
++------------+------+----+-----+-----+------+-------+-----------+-----------+
+|  FILENAME  | CRLF | LF | TAB | NUL | BOM8 | BOM16 | NON-ASCII | BYTESREAD |
++------------+------+----+-----+-----+------+-------+-----------+-----------+
+| /etc/group |    0 | 58 |   0 |   0 |    0 |     0 |         0 |       795 |
++------------+------+----+-----+-----+------+-------+-----------+-----------+
 
 100
 ```
@@ -152,16 +152,16 @@ $ chars -e '^go' -j * | jq -r '.[] | select(.tab > 0) | [.filename,.tab] | @csv'
 
 ```ps1con
 PS C:\chars> .\chars.exe -t -c -e "\.g.*" *
-+-----------------+------+-----+-----+-----+------+-------+-----------+
-|    FILENAME     | CRLF | LF  | TAB | NUL | BOM8 | BOM16 | BYTESREAD |
-+-----------------+------+-----+-----+-----+------+-------+-----------+
-| LICENSE         |    0 |  21 |   0 |   0 |    0 |     0 |     1,068 |
-| README.md       |    0 | 178 |   4 |   0 |    0 |     0 |     6,656 |
-| STATUS.md       |    0 |  50 |   0 |   0 |    0 |     0 |     3,055 |
-| go.mod          |    0 |  11 |   3 |   0 |    0 |     0 |       214 |
-| go.sum          |    0 |   9 |   0 |   0 |    0 |     0 |       795 |
-| TOTALS: 5 files |    0 | 269 |   7 |   0 |    0 |     0 |    11,788 |
-+-----------------+------+-----+-----+-----+------+-------+-----------+
++-----------------+------+-----+-----+-----+------+-------+-----------+-----------+
+|    FILENAME     | CRLF | LF  | TAB | NUL | BOM8 | BOM16 | NON-ASCII | BYTESREAD |
++-----------------+------+-----+-----+-----+------+-------+-----------+-----------+
+| LICENSE         |    0 |  21 |   0 |   0 |    0 |     0 |         0 |     1,068 |
+| README.md       |    0 | 178 |   4 |   0 |    0 |     0 |         0 |     6,656 |
+| STATUS.md       |    0 |  50 |   0 |   0 |    0 |     0 |         0 |     3,055 |
+| go.mod          |    0 |  11 |   3 |   0 |    0 |     0 |         0 |       214 |
+| go.sum          |    0 |   9 |   0 |   0 |    0 |     0 |         0 |       795 |
+| TOTALS: 5 files |    0 | 269 |   7 |   0 |    0 |     0 |         0 |    11,788 |
++-----------------+------+-----+-----+-----+------+-------+-----------+-----------+
 ```
 
 ___
@@ -193,4 +193,4 @@ ___
 
 * [ellipsis](https://github.com/jftuga/ellipsis) - Go module to insert an ellipsis into the middle of a long string to shorten it
 * [tablewriter](https://github.com/olekukonko/tablewriter) - ASCII table in golang
-* [/u/skeeto](https://old.reddit.com/user/skeeto) and [/u/petreus](https://old.reddit.com/user/ppetreus) provided [code review and suggestions](https://old.reddit.com/r/golang/comments/s64jye/i_wrote_a_cli_tool_to_determine_the_endofline/) 
+* [/u/skeeto](https://old.reddit.com/user/skeeto) and [/u/petreus](https://old.reddit.com/user/ppetreus) provided [code review and suggestions](https://old.reddit.com/r/golang/comments/s64jye/i_wrote_a_cli_tool_to_determine_the_endofline/)

--- a/cmd/chars/cmd.go
+++ b/cmd/chars/cmd.go
@@ -42,7 +42,7 @@ func main() {
 	argsMaxLength := flag.Int("l", 0, "shorten files names to a maximum of this length")
 	argsJSON := flag.Bool("j", false, "output results in JSON format; can't be used with -l; does not honor -t or -c")
 	argsVersion := flag.Bool("v", false, "display version and then exit")
-	argsFail := flag.String("f", "", "fail with OS exit code=100 if any of the included characters exist; ex: -f crlf,nul,bom8")
+	argsFail := flag.String("f", "", "fail with OS exit code=100 if any of the included characters exist; ex: -f crlf,nul,bom8,nonascii")
 	argsFailedFileList := flag.Bool("F", false, "when used with -f, only display a list of failed files, one per line")
 	argsTotals := flag.Bool("t", false, "append a row which includes a total for each column")
 	argsComma := flag.Bool("c", false, "add comma thousands separator to numeric values")

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/jftuga/chars
 
-go 1.17
+go 1.24.2
 
 require (
 	github.com/jftuga/ellipsis v1.0.0
 	github.com/olekukonko/tablewriter v0.0.5
-	golang.org/x/text v0.3.7
+	golang.org/x/text v0.24.0
 )
 
 require github.com/mattn/go-runewidth v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,5 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=


### PR DESCRIPTION
Add a `NON-ASCII` column

**Example:**

```console
+------------------+------+-----+-----+-----+------+-------+-----------+-----------+
|     FILENAME     | CRLF | LF  | TAB | NUL | BOM8 | BOM16 | NON-ASCII | BYTESREAD |
+------------------+------+-----+-----+-----+------+-------+-----------+-----------+
| LICENSE          |    0 |  21 |   0 |   0 |    0 |     0 |         0 |      1068 |
| README.md        |    0 | 196 |   9 |   0 |    0 |     0 |         0 |      8040 |
| STATUS.md        |    0 |  50 |   0 |   0 |    0 |     0 |         0 |      3055 |
| case.go          |    0 |  74 |  80 |   0 |    0 |     0 |         0 |      1839 |
| chars.go         |    0 | 390 | 619 |   0 |    0 |     0 |         0 |     10179 |
| go.mod           |    0 |  11 |   3 |   0 |    0 |     0 |         0 |       217 |
| go.sum           |    0 |   8 |   0 |   0 |    0 |     0 |         0 |       688 |
| render_number.go |    0 | 196 | 253 |   0 |    0 |     0 |         3 |      4590 |
+------------------+------+-----+-----+-----+------+-------+-----------+-----------+
```
