### PR TITLE
feat: sort output by column

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,27 @@ Determine the end-of-line format, tabs, bom, and nul characters
 * For help, run `chars -h`
 
 ```
-chars v2.5.0
+
+chars v2.6.0
 Determine the end-of-line format, tabs, bom, and nul
 https://github.com/jftuga/chars
 
 Usage:
 chars [filename or file-glob 1] [filename or file-glob 2] ...
-  -F	when used with -f, only display a list of failed files, one per line
-  -b	examine binary files
-  -c	add comma thousands separator to numeric values
+  -F    when used with -f, only display a list of failed files, one per line
+  -b    examine binary files
+  -c    add comma thousands separator to numeric values
   -e string
         exclude based on regular expression; use .* instead of *
   -f string
         fail with OS exit code=100 if any of the included characters exist; ex: -f crlf,nul,bom8,nonascii
-  -j	output results in JSON format; can't be used with -l; does not honor -t or -c
+  -j    output results in JSON format; can't be used with -l; does not honor -t or -c
   -l int
         shorten files names to a maximum of this length
-  -t	append a row which includes a total for each column
-  -v	display version and then exit
+  -s string
+        sort output by column: filename, crlf, lf, tab, nul, bom8, bom16, nonascii, bytesread (default "filename")
+  -t    append a row which includes a total for each column
+  -v    display version and then exit
 
 Notes:
 Use - to read a file from STDIN

--- a/chars.go
+++ b/chars.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -30,7 +31,7 @@ import (
 const PgmName string = "chars"
 const PgmDesc string = "Determine the end-of-line format, tabs, bom, and nul"
 const PgmUrl string = "https://github.com/jftuga/chars"
-const PgmVersion string = "2.5.0"
+const PgmVersion string = "2.6.0"
 const BlockSize int = 4096
 
 type SpecialChars struct {
@@ -387,4 +388,55 @@ func GetFailures(commaList string, allStats *[]SpecialChars) uint64 {
 		}
 	}
 	return totalFailures
+}
+
+// sortByColumn - sorts a slice of SpecialChars by the specified column
+func SortByColumn(entries []SpecialChars, column string) {
+	// Define a mapping of column names to comparison functions
+	compareFuncs := map[string]func(i, j int) bool{
+		"filename": func(i, j int) bool {
+			return strings.ToLower(entries[i].Filename) < strings.ToLower(entries[j].Filename)
+		},
+		"crlf": func(i, j int) bool {
+			return entries[i].Crlf < entries[j].Crlf
+		},
+		"lf": func(i, j int) bool {
+			return entries[i].Lf < entries[j].Lf
+		},
+		"tab": func(i, j int) bool {
+			return entries[i].Tab < entries[j].Tab
+		},
+		"nul": func(i, j int) bool {
+			return entries[i].Nul < entries[j].Nul
+		},
+		"bom8": func(i, j int) bool {
+			return entries[i].Bom8 < entries[j].Bom8
+		},
+		"bom16": func(i, j int) bool {
+			return entries[i].Bom16 < entries[j].Bom16
+		},
+		"nonascii": func(i, j int) bool {
+			return entries[i].NonAscii < entries[j].NonAscii
+		},
+		"bytesread": func(i, j int) bool {
+			return entries[i].BytesRead < entries[j].BytesRead
+		},
+	}
+
+	// Get the comparison function for the specified column
+	compareFunc, ok := compareFuncs[strings.ToLower(column)]
+	if !ok {
+		// Default to sorting by filename if the column is not recognized
+		compareFunc = compareFuncs["filename"]
+	}
+
+	// Sort the entries
+	sort.Slice(entries, compareFunc)
+}
+
+// GetValidSortColumns - returns a list of valid column names for sorting
+func GetValidSortColumns() []string {
+	return []string{
+		"filename", "crlf", "lf", "tab", "nul", "bom8", "bom16", "nonascii", "bytesread",
+	}
 }


### PR DESCRIPTION
Add the following command-line feature:

```shell
  -s string
    	sort output by column: filename, crlf, lf, tab, nul, bom8, bom16, nonascii, bytesread (default "filename")
```

**Example -- sort by `tab`:**

```console
$ chars -t -c -s tab .git/*/*
+--------------------------------------+------+-----+-----+-----+------+-------+-----------+-----------+
|               FILENAME               | CRLF | LF  | TAB | NUL | BOM8 | BOM16 | NON-ASCII | BYTESREAD |
+--------------------------------------+------+-----+-----+-----+------+-------+-----------+-----------+
| .git/hooks/pre-merge-commit.sample   |    0 |  13 |   0 |   0 |    0 |     0 |         0 |       416 |
| .git/hooks/applypatch-msg.sample     |    0 |  15 |   0 |   0 |    0 |     0 |         0 |       478 |
| .git/info/exclude                    |    0 |   6 |   0 |   0 |    0 |     0 |         0 |       240 |
| .git/hooks/post-update.sample        |    0 |   8 |   0 |   0 |    0 |     0 |         0 |       189 |
| .git/hooks/pre-applypatch.sample     |    0 |  14 |   0 |   0 |    0 |     0 |         0 |       424 |
| .git/hooks/prepare-commit-msg.sample |    0 |  42 |   1 |   0 |    0 |     0 |         0 |     1,492 |
| .git/logs/HEAD                       |    0 |   3 |   3 |   0 |    0 |     0 |         0 |       553 |
| .git/hooks/commit-msg.sample         |    0 |  24 |   5 |   0 |    0 |     0 |         0 |       896 |
| .git/hooks/push-to-checkout.sample   |    0 |  78 |   8 |   0 |    0 |     0 |         0 |     2,783 |
| .git/hooks/pre-commit.sample         |    0 |  49 |  10 |   0 |    0 |     0 |         0 |     1,643 |
| .git/hooks/pre-receive.sample        |    0 |  24 |  25 |   0 |    0 |     0 |         0 |       544 |
| .git/hooks/pre-push.sample           |    0 |  53 |  44 |   0 |    0 |     0 |         0 |     1,374 |
| .git/hooks/pre-rebase.sample         |    0 | 169 |  99 |   0 |    0 |     0 |         0 |     4,898 |
| .git/hooks/update.sample             |    0 | 128 | 125 |   0 |    0 |     0 |         0 |     3,650 |
| .git/hooks/fsmonitor-watchman.sample |    0 | 174 | 140 |   0 |    0 |     0 |         0 |     4,726 |
| TOTALS: 15 files                     |    0 | 800 | 460 |   0 |    0 |     0 |         0 |    24,306 |
+--------------------------------------+------+-----+-----+-----+------+-------+-----------+-----------+
```