### PR TITLE
Add MAX-CONSEC column to track longest consecutive non-ASCII sequences

### DIFF
--- a/cmd/chars/cmd.go
+++ b/cmd/chars/cmd.go
@@ -47,7 +47,7 @@ func main() {
 	argsFailedFileList := flag.Bool("F", false, "when used with -f, only display a list of failed files, one per line")
 	argsTotals := flag.Bool("t", false, "append a row which includes a total for each column")
 	argsComma := flag.Bool("c", false, "add comma thousands separator to numeric values")
-	argsSortBy := flag.String("s", "filename", "sort output by column: filename, crlf, lf, tab, nul, bom8, bom16, nonascii, bytesread")
+	argsSortBy := flag.String("s", "filename", "sort output by column: filename crlf lf tab nul bom8 bom16 nonascii maxconsec bytesread")
 
 	flag.Usage = Usage
 	flag.Parse()


### PR DESCRIPTION
# Description
Added a new column that displays the longest sequence of consecutive non-ASCII characters in each file. This provides more context about non-ASCII content beyond just counting total occurrences.

# Features
- Added `MaxConsecutiveNonAscii` field to track longest non-ASCII sequences 
- Added "MAX-CONSEC" column to output table
- Added "maxconsec" sort option
- Added "maxconsec" to failure check options
- Skips summing this column in totals row (displays "---")
- All counting done in single file scan pass - no performance impact

# Changes
- Updated version to 2.7.0
- Updated help text
- Added new column `max consec N-A` to table display
- Added `maxconsec` to valid sort columns and  to failure check options

# Non-Changes
* The `README.md` still reflects version `2.6.0` without this new column
* * PRs welcomed.
